### PR TITLE
Prefer stdlib `strings.Cut()` rather than third party dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
           # When updating go.mod or go.sum, update this sha together as following
           # vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
           # `pkgs.lib.fakeSha256` returns invalid string in thesedays... :<;
-          vendorHash = "sha256-HWedQeslWH3/F+7su/7+we16SGoBnXpbJFEjw1uxI6w=";
+          vendorHash = "sha256-9gLpgnJ9y0XSuDlKthZ4q+q2GBZ7/Ji2/BL/S2wAcdc=";
         };
 
         packages.default = packages.selfup;

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.22.0
 
 require (
 	github.com/fatih/color v1.16.0
-	github.com/huandu/xstrings v1.4.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
-github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
-github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -9,8 +7,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.19.0 h1:+ThwsDv+tYfnJFhF4L8jITxu1tdTWRTZpdsWgEgjL6Q=

--- a/internal/selfup.go
+++ b/internal/selfup.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/huandu/xstrings"
 	"golang.org/x/xerrors"
 )
 
@@ -51,8 +50,8 @@ func Update(path string, prefix string, skipBy string, isColor bool) (Result, er
 			newLines = append(newLines, line)
 			continue
 		}
-		head, match, tail := xstrings.LastPartition(line, prefix)
-		if head == "" {
+		head, tail, found := strings.Cut(line, prefix)
+		if !found {
 			newLines = append(newLines, line)
 			continue
 		}
@@ -105,7 +104,7 @@ func Update(path string, prefix string, skipBy string, isColor bool) (Result, er
 			}
 			suffix = fmt.Sprintf(" => %s", replacer)
 		}
-		newLines = append(newLines, replaced+match+tail)
+		newLines = append(newLines, replaced+prefix+tail)
 		fmt.Println(fmt.Sprintf("%s %s:%d: %s", estimation, path, lineNumber, extracted) + suffix)
 	}
 


### PR DESCRIPTION
Noticed when addressing #162
https://stackoverflow.com/questions/19683612/partition-a-string-in-go