### PR TITLE
Update to go 1.23

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
                 nil
                 nixfmt-rfc-style
 
-                go_1_22
+                go_1_23
                 dprint
                 goreleaser
                 typos

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
           version = "v1.1.3";
         in
         rec {
-          selfup = pkgs.buildGo122Module {
+          selfup = pkgs.buildGo123Module {
             pname = "selfup";
             src = pkgs.lib.cleanSource self;
             version = version;

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kachick/selfup
 
-go 1.22.0
+go 1.23.1
 
 require (
 	github.com/fatih/color v1.17.0


### PR DESCRIPTION
- **Bump go version to 1.23 in flake**
- **Bump buildGoModule**
- **`go get "go@$(go version | grep -oP '(?<=go)\d\S+')"`**

https://tip.golang.org/doc/go1.23
