### PR TITLE
Bump go.mod and vendorHash with adjusting to nix-update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.23.1
 require (
 	github.com/fatih/color v1.18.0
 	github.com/google/go-cmp v0.7.0
-	golang.org/x/term v0.31.0
+	golang.org/x/term v0.32.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 )
 
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,9 +9,9 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
-golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
-golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
+golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/package.nix
+++ b/package.nix
@@ -29,7 +29,7 @@ buildGo123Module rec {
   ];
 
   # When updating go.mod or go.sum, update this sha together with `nix-update selfup --version=skip --flake`
-  vendorHash = "sha256-HkViZe6DfFOHe6j2R03pH5FV0Y6YXhbGPOraTnTsa6g=";
+  vendorHash = "sha256-rLS2bLpPM0Uo/fhLXTwBTimO0r8Y3IvYvMa3mK36DyQ=";
 
   # https://github.com/kachick/times_kachick/issues/316
   # TODO: Use env after nixos-25.05. See https://github.com/NixOS/nixpkgs/commit/905dc8d978b38b0439905cb5cd1faf79163e1f14#diff-b07c2e878ff713081760cd5dcf0b53bb98ee59515a22e6007cc3d974e404b220R24

--- a/package.nix
+++ b/package.nix
@@ -11,18 +11,17 @@ in
 buildGo123Module rec {
   pname = "selfup";
   version = "1.1.9";
-  src =
-    with lib.fileset;
-    toSource rec {
-      root = ./.;
-      # Don't just use `fileset.gitTracked root`, then always rebuild even if just changed the README.md
-      fileset = intersection (gitTracked root) (unions [
-        ./go.mod
-        ./go.sum
-        ./cmd
-        ./internal
-      ]);
-    };
+  src = lib.fileset.toSource {
+    root = ./.;
+    # - Don't just use `fileset.gitTracked root`, then always rebuild even if just changed the README.md
+    # - Don't use gitTracked for now, even if filtering with intersection, the feature is not supported in nix-update. See https://github.com/Mic92/nix-update/issues/335
+    fileset = lib.fileset.unions [
+      ./go.mod
+      ./go.sum
+      ./cmd
+      ./internal
+    ];
+  };
   # src = lib.cleanSource self; # Requires this old style if I use nix-update
   ldflags = [
     "-X main.version=v${version}"


### PR DESCRIPTION
- **Bump golang.org/x/term from 0.31.0 to 0.32.0**
- **Don't depend on lib.fileset.gitTracked**
- **`nix-update selfup --version=skip --flake`**

This PR includes https://github.com/kachick/selfup/pull/354